### PR TITLE
Add new field type: email pulldown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+WIP
+
+- Add new field type: email pulldown
+
 1.0.4 (December 7, 2016)
 
 - Add version cache breaker

--- a/app/fieldtypes.vue
+++ b/app/fieldtypes.vue
@@ -34,6 +34,7 @@
             'checkbox': require(`../fieldtypes/checkbox/checkbox.vue`),
             'dob': require(`../fieldtypes/dob/dob.vue`),
             'email': require(`../fieldtypes/email/email.vue`),
+            'emailpulldown': require(`../fieldtypes/emailpulldown/emailpulldown.vue`),
             'htmlcode': require(`../fieldtypes/htmlcode/htmlcode.vue`),
             'map': require(`../fieldtypes/map/map.vue`),
             'pulldown': require(`../fieldtypes/pulldown/pulldown.vue`),

--- a/fieldtypes/emailpulldown/emailpulldown.vue
+++ b/fieldtypes/emailpulldown/emailpulldown.vue
@@ -1,0 +1,53 @@
+<template>
+
+    <div :class="classes(['uk-form-row'], field.data.classSfx)">
+        <label :for="fieldid" class="uk-form-label" v-show="!field.data.hide_label">{{ fieldLabel | trans }}
+            <a v-if="field.data.help_text && field.data.help_show == 'tooltip_icon'"
+               class="uk-icon-info uk-icon-hover uk-margin-small-top uk-float-right"
+               :title="field.data.help_text" data-uk-tooltip="{delay: 100}"></a>
+        </label>
+
+        <div class="uk-form-controls">
+
+            <select class="uk-form-width-large"
+                    :name="fieldid"
+                    v-bind="{id: fieldid, size:field.data.size > 1 ? field.data.size : false}"
+                    v-model="inputValue"
+                    v-validate:required="fieldRequired">
+                <option v-for="option in field.options" :value="option.value">{{ option.text }}</option>
+            </select>
+
+            <p v-if="field.data.help_text && field.data.help_show == 'block'"
+               class="uk-form-help-block">{{{field.data.help_text}}}</p>
+
+            <p class="uk-form-help-block uk-text-danger" v-show="fieldInvalid(form)">{{ fieldRequiredMessage }}</p>
+        </div>
+    </div>
+
+</template>
+
+<script>
+
+    module.exports = {
+
+        mixins: [BixieFieldtypeMixin],
+
+        settings: {},
+
+        appearance: {
+            'size': {
+                type: 'number',
+                label: 'Size',
+                attrs: {'class': 'uk-form-width-small uk-text-right', 'min': 1}
+            }
+        },
+
+        data: function () {
+            return {
+                fieldid: _.uniqueId('formmakerfield_')
+            };
+        }
+
+    };
+
+</script>

--- a/fieldtypes/emailpulldown/index.php
+++ b/fieldtypes/emailpulldown/index.php
@@ -1,0 +1,12 @@
+<?php
+return [
+    'id' => 'emailpulldown',
+    'label' => __('Email Pulldown'),
+    'config' => [
+        'hasOptions' => 1,
+        'optionTypeEmail' => 1,
+        'required' => -1,
+        'size' => 1,
+        'placeholder' => ''
+    ]
+];


### PR DESCRIPTION
Lets the user choose from a pre-defined set of options like a normal pulldown. But additionally to text and value an email for each select option is stored.

Required for Bixie/pagekit-formmaker#18